### PR TITLE
Add initial support for importing SVG files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ settings.json
 
 # Compiled resource cache (though this is sent out with production versions)
 .sass-cache
+
+# WebStorm project files
+/.idea

--- a/locales/en-US/app-en-US.json
+++ b/locales/en-US/app-en-US.json
@@ -63,7 +63,7 @@
     "color3": "Dark"
   },
   "import": {
-    "title": "Import image for tracing…",
+    "title": "Import image for tracing or SVG for editing…",
     "files": "Web format tracing image"
   },
   "export": {

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -317,5 +317,10 @@ module.exports = function(paper) {
     }
   }
 
+  tool.selectNewSvg = function(item) {
+    initSelectionRectangle(item);
+    tool.activate();
+  };
+
   return tool;
 };


### PR DESCRIPTION
Possible optimizations on imported files:
- Automatically map SVG colors to the closest bot palette color by [Euclidean distance](https://github.com/zeke/euclidean-distance) in [Lab color space](https://en.wikipedia.org/wiki/Lab_color_space).
- [Simplify](http://mourner.github.io/simplify-js/) path complexity.
- Optimize the draw order with something like a [simulated annealing](https://en.wikipedia.org/wiki/Simulated_annealing) or [2-opt](https://en.wikipedia.org/wiki/2-opt) algorithm. ![2-opt](https://cloud.githubusercontent.com/assets/108018/11967353/fc2d6b7e-a8b6-11e5-9e57-82799e36a5d4.png)

WIP PR :smile: 
