### PR TITLE
Cut/copy/paste, multiple selection, and Edit menu

### DIFF
--- a/locales/en-US/menus-en-US.json
+++ b/locales/en-US/menus-en-US.json
@@ -15,6 +15,13 @@
     "save": "&Save Project",
     "saveas": "Save Project &as…"
   },
+  "edit" : {
+    "cut": "Cut",
+    "copy": "&Copy",
+    "paste": "Paste",
+    "delete": "Delete",
+    "selectall": "Select &All"
+  },
   "view" : {
     "settings": "Advanced Settings"
   },

--- a/menus/menu-darwin.js
+++ b/menus/menu-darwin.js
@@ -97,6 +97,31 @@ module.exports = function applyTemplate() {
       ]
     },
     {
+      label: 'Edit ', // space prevents OS X from adding Dictation/Emoji menu items
+      submenu: [
+        {
+          key: 'edit.cut',
+          accelerator: 'Command+X'
+        },
+        {
+          key: 'edit.copy',
+          accelerator: 'Command+C'
+        },
+        {
+          key: 'edit.paste',
+          accelerator: 'Command+V'
+        },
+        {
+          key: 'edit.delete',
+          accelerator: 'Backspace'
+        },
+        {
+          key: 'edit.selectall',
+          accelerator: 'Command+A'
+        }
+      ]
+    },
+    {
       label: 'View',
       submenu: [
         {

--- a/menus/menu-win32.js
+++ b/menus/menu-win32.js
@@ -47,6 +47,31 @@ module.exports = function applyTemplate() {
       ]
     },
     {
+      label: 'Edit',
+      submenu: [
+        {
+          key: 'edit.cut',
+          accelerator: 'Control+X'
+        },
+        {
+          key: 'edit.copy',
+          accelerator: 'Control+C'
+        },
+        {
+          key: 'edit.paste',
+          accelerator: 'Control+V'
+        },
+        {
+          key: 'edit.delete',
+          accelerator: 'Delete'
+        },
+        {
+          key: 'edit.selectall',
+          accelerator: 'Control+A'
+        }
+      ]
+    },
+    {
       label: 'View',
       submenu: [
         {

--- a/src/app.js
+++ b/src/app.js
@@ -288,17 +288,17 @@ function selectColor(index) {
 
   // Change selected path's color
   if (paper.selectRect) {
-    if (paper.selectRect.ppath) {
-      if (paper.selectRect.ppath.data.fill === true) {
-        paper.selectRect.ppath.fillColor = paper.pancakeShades[index];
+    _.each(paper.selectRect.paths, function (selectedPath) {
+      if (selectedPath.data.fill === true) {
+        selectedPath.fillColor = paper.pancakeShades[index];
       } else {
-        paper.selectRect.ppath.strokeColor = paper.pancakeShades[index];
+        selectedPath.strokeColor = paper.pancakeShades[index];
       }
 
-      paper.selectRect.ppath.data.color = index;
+      selectedPath.data.color = index;
       paper.view.update();
       currentFile.changed = true;
-    }
+    });
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -247,6 +247,14 @@ function activateToolItem(item) {
   paper.view.update();
 }
 
+function switchToSelectTool() {
+  var selectTool = _.findWhere(paper.tools, { key: 'select'});
+  if (selectTool) {
+    selectTool.activate();
+    activateToolItem($("#tool-select"));
+  }
+}
+
 // Build the elements for the colorpicker non-tool item
 function buildColorPicker() {
   var $picker  = $('<div>').attr('id', 'picker');
@@ -416,6 +424,41 @@ function bindControls() {
           toastr.info(i18n.t(menu));
           paper.newPBP();
         });
+        break;
+      case 'edit.cut':
+        if (paper.tool.key === 'select') {
+          paper.tool.copySelectionToBuffer();
+          paper.tool.deleteSelection();
+          currentFile.changed = true;
+          paper.view.update();
+        }
+        break;
+      case 'edit.copy':
+        if (paper.tool.key === 'select') {
+          paper.tool.copySelectionToBuffer();
+        }
+        break;
+      case 'edit.paste':
+        if (paper.tool.key !== 'select') {
+          switchToSelectTool();
+        }
+        paper.tool.pasteFromBuffer();
+        currentFile.changed = true;
+        paper.view.update();
+        break;
+      case 'edit.delete':
+        if (paper.tool.key === 'select') {
+          paper.tool.deleteSelection();
+          currentFile.changed = true;
+          paper.view.update();
+        }
+        break;
+      case 'edit.selectall':
+        if (paper.tool.key !== 'select') {
+          switchToSelectTool();
+        }
+        paper.tool.selectAll();
+        paper.view.update();
         break;
       case 'view.settings':
         toggleOverlay(true, function(){

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -269,7 +269,7 @@ module.exports = function(paper) {
     paper.deselect();
   }
 
-  function deleteSelection() {
+  tool.deleteSelection = function() {
     if (paper.selectRect !== null) {
       _.each(paper.selectRect.paths, function (selectedPath) {
         selectedPath.remove();
@@ -279,7 +279,7 @@ module.exports = function(paper) {
     paper.deselect();
   }
 
-  function copySelectionToBuffer() {
+  tool.copySelectionToBuffer = function() {
     pasteBuffer = [];
     if (paper.selectRect !== null) {
       var itemsToCopy = paper.selectRect.paths;
@@ -289,7 +289,7 @@ module.exports = function(paper) {
     }
   }
 
-  function pasteFromBuffer() {
+  tool.pasteFromBuffer = function() {
     var addedItems = [];
     _.each(pasteBuffer, function (pasteItem) {
       if (pasteItem[0] === 'Path') {
@@ -304,40 +304,16 @@ module.exports = function(paper) {
     }
   }
 
+  tool.selectAll = function() {
+    initSelectionRectangle(project.activeLayer.getItems({ class: Path }));
+  }
+
   tool.onKeyDown = function (event) {
     if (paper.selectRect) {
-      // Delete a selected path
-      if (event.key === 'delete' || event.key === 'backspace') {
-        deleteSelection();
-      }
-
       // Deselect
       if (event.key === 'escape') {
         cancelSelection();
       }
-
-      // Copy
-      if (event.key === 'c' && !event.event.shiftKey && (event.event.ctrlKey || event.event.metaKey)) {
-        copySelectionToBuffer();
-      }
-
-      // Cut
-      if (event.key === 'x' && !event.event.shiftKey && (event.event.ctrlKey || event.event.metaKey)) {
-        copySelectionToBuffer();
-        deleteSelection();
-      }
-    }
-
-    if (pasteBuffer.length > 0) {
-      // Paste
-      if (event.key === 'v' && !event.event.shiftKey && (event.event.ctrlKey || event.event.metaKey)) {
-        pasteFromBuffer();   
-      }
-    }
-
-    // Select All
-    if (event.key === 'a' && !event.event.shiftKey && (event.event.ctrlKey || event.event.metaKey)) {
-      initSelectionRectangle(project.activeLayer.getItems({ class: Path }));
     }
   };
 

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -309,6 +309,10 @@ module.exports = function(paper) {
       }
     }
 
+    // Select All
+    if (event.key === 'a' && !event.event.shiftKey && (event.event.ctrlKey || event.event.metaKey)) {
+      initSelectionRectangle(project.activeLayer.getItems({ class: Path }));
+    }
   };
 
   function initSelectionRectangle(paths) {

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -295,6 +295,8 @@ module.exports = function(paper) {
       if (pasteItem[0] === 'Path') {
         var newPath = new Path();
         newPath.importJSON(JSON.stringify(pasteItem));
+        newPath.position.x += 15;
+        newPath.position.y += 15;
         addedItems.push(newPath);
       }
     });
@@ -318,6 +320,7 @@ module.exports = function(paper) {
   };
 
   function initSelectionRectangle(paths) {
+    paths = _.filter(paths, function(p) { return p !== paper.selectRect });
     cancelSelection();
 
     if (paths.length <= 0) {

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -169,6 +169,7 @@ module.exports = function(paper) {
       paper.selectRect.scaling = scaling;
       _.each(paper.selectRect.paths, function (selectedPath) {
         selectedPath.scaling = scaling;
+        selectedPath.strokeWidth = 4 / ratio;
       });
       return;
     } else if (selectionRectangleRotation !== null) {
@@ -193,6 +194,9 @@ module.exports = function(paper) {
     } else if (paper.selectRect !== null && paper.selectRect.paths.length > 0) {
       // Path translate position adjustment
       _.each(paper.selectRect.paths, function (selectedPath) {
+        selectedPath.applyMatrix = true;
+        selectedPath.applyMatrix = false;
+        selectedPath.strokeWidth = 4;
         selectedPath.position = selectedPath.position.add(event.delta);
       });
       paper.selectRect.position = paper.selectRect.position.add(event.delta);
@@ -355,6 +359,7 @@ module.exports = function(paper) {
       // Apply previous rotation to segments before moving pivot
       selectedPath.applyMatrix = true;
       selectedPath.applyMatrix = false;
+      selectedPath.strokeWidth = 4;
       selectedPath.pivot = paper.selectRect.pivot;
     });
   }

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -135,19 +135,23 @@ module.exports = function(paper) {
         }
       }
 
+      // Selection
+      var isMultiSelect = event.modifiers.command || event.modifiers.control;
       if ((paper.selectRect === null || !_.contains(paper.selectRect.paths, path)) && paper.selectRect !== path) {
-        if (!event.modifiers.shift || paper.selectRect === null) {
+        if (!isMultiSelect || paper.selectRect === null) {
+          // Start a new selection with this path
           initSelectionRectangle([path]);
         } else {
+          // Multiselect key held, add this path to the existing selection
           var newSelection = paper.selectRect.paths;
           newSelection.push(path);
           initSelectionRectangle(newSelection);
         }
-      } else if (paper.selectRect !== null && _.contains(paper.selectRect.paths, path)) {
-        if (event.modifiers.shift) {
-          var newSelection = _.filter(paper.selectRect.paths, function (p) { return p !== path });
-          initSelectionRectangle(newSelection);
-        }
+      }
+      // When multiselect key is held and path is already selected, remove it from selection
+      else if (isMultiSelect && paper.selectRect !== null && _.contains(paper.selectRect.paths, path)) {
+        var newSelection = _.filter(paper.selectRect.paths, function (p) { return p !== path });
+        initSelectionRectangle(newSelection);
       }
     }
 

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -373,6 +373,9 @@ module.exports = function(paper) {
     paper.selectRect.paths = paths;
 
     _.each(paths, function (selectedPath) {
+      // Apply previous rotation to segments before moving pivot
+      selectedPath.applyMatrix = true;
+      selectedPath.applyMatrix = false;
       selectedPath.pivot = paper.selectRect.pivot;
     });
   }


### PR DESCRIPTION
### What this pull request does
- Adds Cut, Copy, and Paste commands with the standard keyboard shortcuts, which work on paths and fills (not images.)
- Adds a Select All command (Cmd-A / Ctrl-A) which selects all paths.
- Adds an "Edit" menu containing the above commands, plus Delete
- Multiple selection:
  - Clicking on a path while holding Cmd or Ctrl will add/remove it from the current selection
  - Clicking in empty space and dragging will draw a selection rectangle, any paths completely within the rectangle will be selected on mouse-up.
### Issues addressed
#57 Add support for select-all resizing
#54 Group selection and group scaling/movement
#48 Copy and paste functionality
#32 Wish list (sixth bullet "Multi-select")
### Testing performed
- Manual testing only, tested path drawing/rotating/scaling/moving heavily, fills less heavily. 
- Any plans for / interest in adding Selenium tests in the future?
### Notes
- Have not tested the menu additions on Windows yet
- The original implementation uses Paper.js's default approach of managing rotation/scale as a local transform on the path item, never modifying the original segment data. Unfortunately this strategy doesn't work for rotating and scaling multiple paths at once. I had to do a little dance with `applyMatrix` to make sure successive multiple-selection rotations and scales are applied correctly. There may be a better way to manage this, possibly by leaving `applyMatrix` on all the time and directly applying all transformations. I instead erred on the side of making fewer changes to the code. It works, but if new editing tools are added they'll likely need similar `applyMatrix` hacks.
