### PR TITLE
Clipboard cut/copy/paste/duplication support

### DIFF
--- a/menus/menu-win32.js
+++ b/menus/menu-win32.js
@@ -72,7 +72,10 @@ module.exports = function applyTemplate() {
           key: 'edit.paste',
           accelerator: 'Control+v'
         },
-
+        {
+          key: 'edit.duplicate',
+          accelerator: 'Control+d'
+        }
       ]
     },
     {

--- a/src/app.js
+++ b/src/app.js
@@ -334,6 +334,9 @@ function buildImageImporter() {
 
 // When the page is done loading, all the controls in the page can be bound.
 function bindControls() {
+  // Bind cut/copy/paste controls... Cause they're not always caught.
+  $(window).keydown(paper.handleClipboard);
+
   // Callback/event for when any menu item is clicked
   app.menuClick = function(menu, callback) {
     switch (menu) {
@@ -446,6 +449,12 @@ function bindControls() {
       case 'edit.undo':
       case 'edit.redo':
         paper.handleUndo(menu === 'edit.undo' ? 'undo': 'redo');
+        break;
+      case 'edit.copy':
+      case 'edit.cut':
+      case 'edit.paste':
+      case 'edit.duplicate':
+        paper.handleClipboard(menu.split('.')[1]);
         break;
       case 'view.settings':
         toggleOverlay(true, function(){

--- a/src/editor.ps.js
+++ b/src/editor.ps.js
@@ -38,6 +38,7 @@ var toolSelect = require('./tools/tool.select')(paper);
 
 // Load Helpers
 paper.undo = require('./helpers/helper.undo')(paper);
+paper.clipboard = require('./helpers/helper.clipboard')(paper);
 
 var $editor = $('#editor');
 paper.setCursor = function(type) {
@@ -163,6 +164,53 @@ paper.handleUndo = function(op) {
     paper.undo.goForward();
   }
 };
+
+// Handle clipboard requests
+paper.handleClipboard = function(op) {
+  // For clarity, don't do any clipboard operations if not on the select tool.
+  if (paper.tool.name !== 'tools.select') {
+    return;
+  }
+
+  // Support "event" passthrough from window keydown event.
+  var event = op;
+  if (typeof op === 'object') {
+    if (event.ctrlKey && event.keyCode === 67) {
+      op = 'copy';
+    }
+    if (event.ctrlKey && event.keyCode === 88) {
+      op = 'cut';
+    }
+    if (event.ctrlKey && event.keyCode === 86) {
+      op = 'paste';
+    }
+    if (event.ctrlKey && event.keyCode === 68) {
+      op = 'duplicate';
+    }
+
+    // If our captured keystroke didn't result in valid op, quit.
+    if (typeof op !== 'string') {
+      return;
+    }
+
+    // Prevent whatever else was going to happen.
+    event.preventDefault();
+  }
+
+  switch (op) {
+    case 'cut':
+    case 'copy':
+      paper.clipboard.copy(op === 'cut');
+      break;
+    case 'paste':
+      paper.clipboard.paste();
+      break;
+    case 'duplicate':
+      paper.clipboard.dupe();
+      break;
+  }
+};
+
 
 // Render the text/SVG for the pancakebot project files
 paper.getPBP = function(){

--- a/src/helpers/helper.clipboard.js
+++ b/src/helpers/helper.clipboard.js
@@ -1,0 +1,91 @@
+/**
+ * @file This is a helper include for adding clipboard (copy/cut/paste/dupe)
+ * support.
+ **/
+"use strict";
+/*globals _ */
+
+module.exports = function(paper) {
+  var clipboard = {};
+
+  var view = paper.view;
+  var project = paper.project;
+  var Point = paper.Point;
+
+  // Array of paths to paste during a cut/copy.
+  clipboard.data = [];
+
+  /**
+   * "Clipboard" copy: Duplicate a path selection into the data space.
+   *
+   * @param  {boolean} deleteSelection
+   *   Pass true to delete the selection after copying.
+   *
+   * @return {undefined}
+   */
+  clipboard.copy = function(deleteSelection) {
+    if (paper.selectRect) {
+      clipboard.data = [];
+      _.each(paper.selectRect.ppaths, function(path){
+        clipboard.data.push(path.clone(false));
+        if (deleteSelection) path.remove();
+      });
+
+      if (deleteSelection) {
+        paper.fileChanged();
+        paper.deselect();
+        view.update();
+      }
+    }
+  };
+
+  /**
+   * "Clipboard" paste: Duplicate and offset the paths saved in the data space.
+   *
+   * @return {undefined}
+   */
+  clipboard.paste = function() {
+    if (clipboard.data.length) {
+      // Deselect when pasting.
+      paper.deselect();
+
+      // Clone each path, put in the layer, offset it, and add to selection.
+      _.each(clipboard.data, function(path){
+        var pathCopy = path.clone(false);
+        project.activeLayer.addChild(pathCopy);
+        pathCopy.translate(new Point(25, 25));
+        paper.selectAdd(pathCopy);
+      });
+
+      paper.fileChanged();
+      view.update();
+    }
+  };
+
+  /**
+   * "Clipboard" duplication: Duplicate selected paths w/out saving data.
+   *
+   * @return {undefined}
+   */
+  clipboard.dupe = function() {
+    if (paper.selectRect) {
+      var newPaths = [];
+      _.each(paper.selectRect.ppaths, function(path){
+        newPaths.push(path.clone(true));
+      });
+
+      // Deselect to clear for selecting the new paths.
+      paper.deselect();
+
+      _.each(newPaths, function(path){
+        path.translate(new Point(25, 25));
+        paper.selectAdd(path);
+      });
+
+      paper.fileChanged();
+      view.update();
+    }
+  };
+
+  return clipboard;
+};

--- a/src/helpers/helper.undo.js
+++ b/src/helpers/helper.undo.js
@@ -2,7 +2,6 @@
  * @file This is a helper include for adding undo/redo functionality for the
  * Paper.JS canvas drawing area.
  **/
- /*globals _ */
 
  module.exports = function(paper) {
    var undo = {};

--- a/src/tools/tool.select.js
+++ b/src/tools/tool.select.js
@@ -58,7 +58,6 @@ module.exports = function(paper) {
 
   tool.onMouseDown = function(event) {
     segment = path = addselect = null;
-    console.log('shift?', event.modifiers.shift);
     var hitResult = project.hitTest(event.point, hitOptions);
 
     // Don't select image if not in trace mode
@@ -157,12 +156,10 @@ module.exports = function(paper) {
 
       if (event.modifiers.shift) {
         if (paper.selectRect !== path) {
-          console.log('Add to Selection');
           addselect = true;
           addToSelection(path);
         }
       } else if (noSel && paper.selectRect !== path) {
-        console.log('NoSel INIT');
         initSelectionRectangle(path);
       }
 
@@ -286,7 +283,6 @@ module.exports = function(paper) {
 
   paper.selectPath = initSelectionRectangle;
   function initSelectionRectangle(path) {
-    console.log('INIT Selection');
     if (paper.selectRect !== null) paper.selectRect.remove();
     var reset = path.rotation === 0 && path.scaling.x === 1 && path.scaling.y === 1;
     var bounds;


### PR DESCRIPTION
Adds basic support for cutting, copying and pasting path selections into a virtual "clipboard", does not use system clipboard without agreed on system wide format.

To be tested by Storebound then merged.
